### PR TITLE
ci: update GitHub Actions to Node 24 before June 2 deadline

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -5,7 +5,7 @@ jobs:
   clippy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: Install Clippy
         run: rustup component add clippy
       - name: Run Clippy

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -5,7 +5,7 @@ jobs:
   clippy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - name: Install Clippy
         run: rustup component add clippy
       - name: Run Clippy

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -5,7 +5,7 @@ jobs:
   clippy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Install Clippy
         run: rustup component add clippy
       - name: Run Clippy

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,8 +31,8 @@ jobs:
           - '3.13'
           - '3.14'
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install Rust toolchain
@@ -51,7 +51,7 @@ jobs:
         run: |
           pip install --find-links dist/ --force-reinstall ${{ env.PACKAGE_NAME }}
       - name: Upload wheels
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: wheels-${{ matrix.target }}-${{ matrix.python-version }}-macos
           path: dist
@@ -68,8 +68,8 @@ jobs:
           - '3.13'
           - '3.14'
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
           architecture: x64
@@ -90,7 +90,7 @@ jobs:
         run: |
           python -m pip install --find-links dist/ --force-reinstall ${{ env.PACKAGE_NAME }}
       - name: Upload wheels
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: wheels-${{ matrix.python-version }}-windows
           path: dist
@@ -108,8 +108,8 @@ jobs:
           - '3.13'
           - '3.14'
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Build wheels
@@ -124,7 +124,7 @@ jobs:
         run: |
           pip install --find-links dist/ --force-reinstall ${{ env.PACKAGE_NAME }}
       - name: Upload wheels
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: wheels-${{ matrix.target }}-${{ matrix.python-version }}-manylinux-${{ matrix.manylinux }}-linux
           path: dist
@@ -141,8 +141,8 @@ jobs:
           - '3.13'
           - '3.14'
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Build wheels
@@ -168,7 +168,7 @@ jobs:
           run: |
             pip3 install ${{ env.PACKAGE_NAME }} --no-index --find-links /dist/ --force-reinstall
       - name: Upload wheels
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: wheels-${{ matrix.target }}-${{ matrix.python-version }}-linux-cross
           path: dist
@@ -186,8 +186,8 @@ jobs:
           - '3.13'
           - '3.14'
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
           architecture: x64
@@ -208,7 +208,7 @@ jobs:
             apk add py3-pip
             pip3 install ${{ env.PACKAGE_NAME }} --break-system-packages --no-index --find-links /io/dist/ --force-reinstall
       - name: Upload wheels
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: wheels-${{ matrix.target }}-${{ matrix.python-version }}-musllinux
           path: dist
@@ -229,8 +229,8 @@ jobs:
           - '3.13'
           - '3.14'
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Build wheels
@@ -252,7 +252,7 @@ jobs:
           run: |
             pip3 install ${{ env.PACKAGE_NAME }} --break-system-packages --no-index --find-links dist/ --force-reinstall
       - name: Upload wheels
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: wheels-${{ matrix.platform.target }}-${{ matrix.python-version }}-musllinux-cross
           path: dist
@@ -266,8 +266,8 @@ jobs:
         python-version:
           - '3.11'
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: pypy${{ matrix.python-version }}
       - name: Build wheels
@@ -282,7 +282,7 @@ jobs:
         run: |
           pip install --find-links dist/ --force-reinstall ${{ env.PACKAGE_NAME }}
       - name: Upload wheels
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: wheels-${{ matrix.os }}-${{ matrix.target }}-${{ matrix.python-version }}-pypy
           path: dist
@@ -312,10 +312,10 @@ jobs:
     # Only run if triggered by a tag push
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: wheels
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v6
       - name: Publish to PyPi
         env:
           TWINE_USERNAME: __token__

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,8 +31,8 @@ jobs:
           - '3.13'
           - '3.14'
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install Rust toolchain
@@ -51,7 +51,7 @@ jobs:
         run: |
           pip install --find-links dist/ --force-reinstall ${{ env.PACKAGE_NAME }}
       - name: Upload wheels
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: wheels-${{ matrix.target }}-${{ matrix.python-version }}-macos
           path: dist
@@ -68,8 +68,8 @@ jobs:
           - '3.13'
           - '3.14'
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: ${{ matrix.python-version }}
           architecture: x64
@@ -90,7 +90,7 @@ jobs:
         run: |
           python -m pip install --find-links dist/ --force-reinstall ${{ env.PACKAGE_NAME }}
       - name: Upload wheels
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: wheels-${{ matrix.python-version }}-windows
           path: dist
@@ -108,8 +108,8 @@ jobs:
           - '3.13'
           - '3.14'
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: ${{ matrix.python-version }}
       - name: Build wheels
@@ -124,7 +124,7 @@ jobs:
         run: |
           pip install --find-links dist/ --force-reinstall ${{ env.PACKAGE_NAME }}
       - name: Upload wheels
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: wheels-${{ matrix.target }}-${{ matrix.python-version }}-manylinux-${{ matrix.manylinux }}-linux
           path: dist
@@ -141,8 +141,8 @@ jobs:
           - '3.13'
           - '3.14'
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: ${{ matrix.python-version }}
       - name: Build wheels
@@ -168,7 +168,7 @@ jobs:
           run: |
             pip3 install ${{ env.PACKAGE_NAME }} --no-index --find-links /dist/ --force-reinstall
       - name: Upload wheels
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: wheels-${{ matrix.target }}-${{ matrix.python-version }}-linux-cross
           path: dist
@@ -186,8 +186,8 @@ jobs:
           - '3.13'
           - '3.14'
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: ${{ matrix.python-version }}
           architecture: x64
@@ -208,7 +208,7 @@ jobs:
             apk add py3-pip
             pip3 install ${{ env.PACKAGE_NAME }} --break-system-packages --no-index --find-links /io/dist/ --force-reinstall
       - name: Upload wheels
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: wheels-${{ matrix.target }}-${{ matrix.python-version }}-musllinux
           path: dist
@@ -229,8 +229,8 @@ jobs:
           - '3.13'
           - '3.14'
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: ${{ matrix.python-version }}
       - name: Build wheels
@@ -252,7 +252,7 @@ jobs:
           run: |
             pip3 install ${{ env.PACKAGE_NAME }} --break-system-packages --no-index --find-links dist/ --force-reinstall
       - name: Upload wheels
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: wheels-${{ matrix.platform.target }}-${{ matrix.python-version }}-musllinux-cross
           path: dist
@@ -266,8 +266,8 @@ jobs:
         python-version:
           - '3.11'
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: pypy${{ matrix.python-version }}
       - name: Build wheels
@@ -282,7 +282,7 @@ jobs:
         run: |
           pip install --find-links dist/ --force-reinstall ${{ env.PACKAGE_NAME }}
       - name: Upload wheels
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: wheels-${{ matrix.os }}-${{ matrix.target }}-${{ matrix.python-version }}-pypy
           path: dist
@@ -298,7 +298,7 @@ jobs:
       - musllinux-cross
       - pypy
     steps:
-      - uses: actions/upload-artifact/merge@v4
+      - uses: actions/upload-artifact/merge@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: wheels
           pattern: wheels-*
@@ -312,7 +312,7 @@ jobs:
     # Only run if triggered by a tag push
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@ad191675b41f6a5b46da9a048cb6893812da158b
         with:
           name: wheels
       - uses: actions/setup-python@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,8 +31,8 @@ jobs:
           - '3.13'
           - '3.14'
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install Rust toolchain
@@ -51,7 +51,7 @@ jobs:
         run: |
           pip install --find-links dist/ --force-reinstall ${{ env.PACKAGE_NAME }}
       - name: Upload wheels
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: wheels-${{ matrix.target }}-${{ matrix.python-version }}-macos
           path: dist
@@ -68,8 +68,8 @@ jobs:
           - '3.13'
           - '3.14'
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
           architecture: x64
@@ -90,7 +90,7 @@ jobs:
         run: |
           python -m pip install --find-links dist/ --force-reinstall ${{ env.PACKAGE_NAME }}
       - name: Upload wheels
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: wheels-${{ matrix.python-version }}-windows
           path: dist
@@ -108,8 +108,8 @@ jobs:
           - '3.13'
           - '3.14'
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Build wheels
@@ -124,7 +124,7 @@ jobs:
         run: |
           pip install --find-links dist/ --force-reinstall ${{ env.PACKAGE_NAME }}
       - name: Upload wheels
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: wheels-${{ matrix.target }}-${{ matrix.python-version }}-manylinux-${{ matrix.manylinux }}-linux
           path: dist
@@ -141,8 +141,8 @@ jobs:
           - '3.13'
           - '3.14'
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Build wheels
@@ -168,7 +168,7 @@ jobs:
           run: |
             pip3 install ${{ env.PACKAGE_NAME }} --no-index --find-links /dist/ --force-reinstall
       - name: Upload wheels
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: wheels-${{ matrix.target }}-${{ matrix.python-version }}-linux-cross
           path: dist
@@ -186,8 +186,8 @@ jobs:
           - '3.13'
           - '3.14'
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
           architecture: x64
@@ -208,7 +208,7 @@ jobs:
             apk add py3-pip
             pip3 install ${{ env.PACKAGE_NAME }} --break-system-packages --no-index --find-links /io/dist/ --force-reinstall
       - name: Upload wheels
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: wheels-${{ matrix.target }}-${{ matrix.python-version }}-musllinux
           path: dist
@@ -229,8 +229,8 @@ jobs:
           - '3.13'
           - '3.14'
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Build wheels
@@ -252,7 +252,7 @@ jobs:
           run: |
             pip3 install ${{ env.PACKAGE_NAME }} --break-system-packages --no-index --find-links dist/ --force-reinstall
       - name: Upload wheels
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: wheels-${{ matrix.platform.target }}-${{ matrix.python-version }}-musllinux-cross
           path: dist
@@ -266,8 +266,8 @@ jobs:
         python-version:
           - '3.11'
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: pypy${{ matrix.python-version }}
       - name: Build wheels
@@ -282,7 +282,7 @@ jobs:
         run: |
           pip install --find-links dist/ --force-reinstall ${{ env.PACKAGE_NAME }}
       - name: Upload wheels
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1  
         with:
           name: wheels-${{ matrix.os }}-${{ matrix.target }}-${{ matrix.python-version }}-pypy
           path: dist
@@ -298,7 +298,7 @@ jobs:
       - musllinux-cross
       - pypy
     steps:
-      - uses: actions/upload-artifact/merge@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+      - uses: actions/upload-artifact/merge@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: wheels
           pattern: wheels-*
@@ -312,10 +312,10 @@ jobs:
     # Only run if triggered by a tag push
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
-      - uses: actions/download-artifact@ad191675b41f6a5b46da9a048cb6893812da158b
+      - uses: actions/download-artifact@ad191675b41f6a5b46da9a048cb6893812da158b  # v8.0.1
         with:
           name: wheels
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
       - name: Publish to PyPi
         env:
           TWINE_USERNAME: __token__

--- a/.github/workflows/rustfmt.yml
+++ b/.github/workflows/rustfmt.yml
@@ -5,7 +5,7 @@ jobs:
   rustfmt:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - name: Install Rustfmt
         run: rustup component add rustfmt
       - name: Check formatting

--- a/.github/workflows/rustfmt.yml
+++ b/.github/workflows/rustfmt.yml
@@ -5,7 +5,7 @@ jobs:
   rustfmt:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Install Rustfmt
         run: rustup component add rustfmt
       - name: Check formatting

--- a/.github/workflows/rustfmt.yml
+++ b/.github/workflows/rustfmt.yml
@@ -5,7 +5,7 @@ jobs:
   rustfmt:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: Install Rustfmt
         run: rustup component add rustfmt
       - name: Check formatting


### PR DESCRIPTION
## Summary

GitHub will force all JavaScript-based actions to run on Node 24 starting **June 2, 2026**.
Node 20 will be removed from runners entirely on September 16, 2026.

This PR updates all `actions/*` references to the latest Node 24-native versions.

## Changes

| Action | From | To | Node |
|--------|------|----|------|
| actions/checkout | v1-v4 | v6.0.2 | 24 |
| actions/setup-python | v2-v5 | v6.2.0 | 24 |
| actions/setup-node | v2-v4 | v6.4.0 | 24 |
| actions/setup-go | v4-v5 | v6.4.0 | 24 |
| actions/cache | v3-v4 | v5.0.5 | 24 |
| actions/upload-artifact | v4 | v7.0.1 | 24 |
| actions/download-artifact | v4-v5 | v8.0.1 | 24 |

All target SHAs verified against their tags via the GitHub API.
All target versions confirmed running Node 24 in their action.yml.

## References

- https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/